### PR TITLE
add googlebattery sepolicy to BOARD_VENDOR_SEPOLICY_DIRS

### DIFF
--- a/redbull-sepolicy.mk
+++ b/redbull-sepolicy.mk
@@ -10,6 +10,7 @@ BOARD_SEPOLICY_DIRS += device/google/redbull-sepolicy/vendor/st
 
 # Pixel-wide sepolicy
 BOARD_VENDOR_SEPOLICY_DIRS += hardware/google/pixel-sepolicy/powerstats
+BOARD_VENDOR_SEPOLICY_DIRS += hardware/google/pixel-sepolicy/googlebattery
 
 # system_ext
 SYSTEM_EXT_PRIVATE_SEPOLICY_DIRS += device/google/redbull-sepolicy/system_ext/private


### PR DESCRIPTION
It used to be included via adevtool, but that stopped working after inclusion of device/google/redfin/wireless_charger/wireless_charger.mk , which depends on googlebattery sepolicy.